### PR TITLE
Implement Frog/Not Frog buttons in Results view alongside accuracy (not overriden images/total images in run)

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -95,6 +95,17 @@ ipcMain.handle("save-csv-dialog", async (event: IpcMainInvokeEvent, runData: Run
   }
 });
 
+ipcMain.handle("update-image-classification", async (event: IpcMainInvokeEvent, runData: RunData) => {
+  try {
+    // Simply overwrite the existing file with updated runData
+    await fs.writeFile(runData.filePath, JSON.stringify(runData, null, 2), "utf-8");
+    return { success: true, filePath: runData.filePath };
+  } catch (error: any) {
+    console.error("Failed to update image classification:", error);
+    return { success: false, error: error.message };
+  }
+});
+
 // Handle listing all runs from Documents/Leapfrog/runs dir
 ipcMain.handle("list-runs", async () => {
   try {
@@ -134,6 +145,15 @@ ipcMain.handle("list-runs", async () => {
   }
 });
 
+interface RunData {
+  filePath: string;
+  runDate: string;
+  frogs: number;
+  notFrogs: number;
+  averageConfidence: number;
+  results: Array<ImageResultData>;
+}
+
 interface ImageResultData {
   name: string;
   imagePath: string;
@@ -150,15 +170,6 @@ function isValidImageResult(result: any): result is ImageResultData {
     typeof result.confidence === "number" &&
     typeof result.override === "boolean"
   );
-}
-
-interface RunData {
-  filePath: string;
-  runDate: string;
-  frogs: number;
-  notFrogs: number;
-  averageConfidence: number;
-  results: Array<ImageResultData>;
 }
 
 function isValidRunData(data: any): data is RunData {

--- a/src/renderer/components/Dashboard.tsx
+++ b/src/renderer/components/Dashboard.tsx
@@ -35,6 +35,7 @@ export default function Dashboard({ onSortClick, onResultsClick }: DashboardProp
       {/* Chart section */}
       <div className="w-full max-w-4xl">
         <h2 className="text-2xl font-semibold text-center mb-6 text-[var(--apple-text)]">Frogs Over Time</h2>
+        <div className="text-xs font-semibold text-center text-[var(--apple-subtle-text)]">Chart functionality not yet implemented; example data shown instead</div>
 
         <div className="mb-4">
           <select


### PR DESCRIPTION
- **feat: frogs/not frogs buttons work;, ResultsView keeps track of override accuracy**
- **fix: add disclaimer to chart since it wasn't implemented this semester**
